### PR TITLE
[Fix] : front server에서의 token 유효시간 parse error로 인한 bug fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>com.github.NHN-YesAladin</groupId>
             <artifactId>yesaladin_common_utils</artifactId>
-            <version>1.3.3</version>
+            <version>1.4.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/shop/yesaladin/auth/controller/AuthenticationController.java
+++ b/src/main/java/shop/yesaladin/auth/controller/AuthenticationController.java
@@ -4,10 +4,8 @@ import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 import static shop.yesaladin.auth.util.AuthUtil.REFRESH_TOKEN;
 
 import java.io.IOException;
-import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
@@ -97,7 +95,7 @@ public class AuthenticationController {
 
         authenticationService.doReissue(memberUuid, reissuedToken);
 
-        LocalDateTime expiredTime = tokenProvider.extractExpiredTime(reissuedToken);
+        long expiredTime = tokenProvider.extractExpiredTime(reissuedToken).getTime();
 
         response.addHeader(AUTHORIZATION, reissuedToken);
         response.addHeader(UUID_HEADER, memberUuid);
@@ -113,10 +111,9 @@ public class AuthenticationController {
                         .get(memberUuid, REFRESH_TOKEN.getValue()))
                         .toString();
 
-        LocalDateTime expiredTime = tokenProvider.extractExpiredTime(refreshToken);
+        long expiredTime = tokenProvider.extractExpiredTime(refreshToken).getTime();
 
-        return Duration.between(LocalDateTime.now(ZoneId.of("Asia/Seoul")), expiredTime)
-                .toMillis() > 0;
+        return (expiredTime - (new Date().getTime() / 1000)) > 0;
     }
 
     /**

--- a/src/main/java/shop/yesaladin/auth/controller/AuthenticationController.java
+++ b/src/main/java/shop/yesaladin/auth/controller/AuthenticationController.java
@@ -113,7 +113,8 @@ public class AuthenticationController {
 
         long expiredTime = tokenProvider.extractExpiredTime(refreshToken).getTime();
 
-        return (expiredTime - (new Date().getTime() / 1000)) > 0;
+        long now = new Date().getTime();
+        return (expiredTime - (now / 1000)) > 0;
     }
 
     /**

--- a/src/main/java/shop/yesaladin/auth/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/shop/yesaladin/auth/filter/JwtAuthenticationFilter.java
@@ -7,7 +7,6 @@ import static shop.yesaladin.auth.util.AuthUtil.USER_ID;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import javax.servlet.FilterChain;
@@ -114,7 +113,7 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String accessToken = getAccessToken(auth);
         String refreshToken = getRefreshToken(auth);
 
-        LocalDateTime expiredTime = jwtTokenProvider.extractExpiredTime(accessToken);
+        long expiredTime = jwtTokenProvider.extractExpiredTime(accessToken).getTime();
         log.info("expiredTime={}", expiredTime);
         String memberUuid = UUID.randomUUID().toString();
 

--- a/src/main/java/shop/yesaladin/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/shop/yesaladin/auth/jwt/JwtTokenProvider.java
@@ -8,8 +8,6 @@ import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
 import java.security.Key;
 import java.time.Duration;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Date;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -155,14 +153,13 @@ public class JwtTokenProvider {
      * @author 송학현
      * @since 1.0
      */
-    public LocalDateTime extractExpiredTime(String token) {
-        Date expiration = Jwts.parserBuilder()
+    public Date extractExpiredTime(String token) {
+        return Jwts.parserBuilder()
                 .setSigningKey(getSecretKey(secretKey))
                 .build()
                 .parseClaimsJws(token)
                 .getBody()
                 .getExpiration();
-        return convertLocalDateTime(expiration);
     }
 
     /**
@@ -200,9 +197,5 @@ public class JwtTokenProvider {
                 "",
                 userDetails.getAuthorities()
         );
-    }
-
-    private LocalDateTime convertLocalDateTime(Date expiration) {
-        return LocalDateTime.ofInstant(expiration.toInstant(), ZoneId.of("Asia/Seoul"));
     }
 }


### PR DESCRIPTION
LocalDateTime format을 사용하지 않고, JWT 자체에 들어있는 exp를 추출하여 long 타입으로 시간 체크하도록 변경하였습니다.